### PR TITLE
Fix broken JQuery calls that prevented config page to load

### DIFF
--- a/Emby.Notification.Slack/Emby.Notification.Slack/Configuration/config.html
+++ b/Emby.Notification.Slack/Emby.Notification.Slack/Configuration/config.html
@@ -168,7 +168,7 @@
 
                         slackConfig.MediaBrowserUserId = userId;
 
-                        slackConfig.Enabled = $('#chkEnableSlack', form).checked;
+                        slackConfig.Enabled = $('#chkEnableSlack', form).prop('checked');
                         slackConfig.SlackWebHookURI = $('#txtSlackWebHookUri', form).val();
                         slackConfig.Channel = $('#txtSlackChannel', form).val();
                         slackConfig.Emoji = $('#txtSlackEmoji', form).val();

--- a/Emby.Notification.Slack/Emby.Notification.Slack/Configuration/config.html
+++ b/Emby.Notification.Slack/Emby.Notification.Slack/Configuration/config.html
@@ -74,7 +74,7 @@
 
                         })[0] || {};
 
-                        $('#chkEnableSlack', page).checked(slackConfig.Enabled || false).checkboxradio("refresh");
+                        $('#chkEnableSlack', page).prop('checked', slackConfig.Enabled || false);
                         $('#txtSlackWebHookUri', page).val(slackConfig.SlackWebHookURI || '');
                         $('#txtSlackChannel', page).val(slackConfig.Channel || '#general');
                         $('#txtSlackEmoji', page).val(slackConfig.Emoji || ':ghost:');
@@ -138,7 +138,7 @@
 
                             return '<option value="' + user.Id + '">' + user.Name + '</option>';
 
-                        })).selectmenu('refresh').trigger('change');
+                        })).trigger('change');
 
                     });
 
@@ -168,7 +168,7 @@
 
                         slackConfig.MediaBrowserUserId = userId;
 
-                        slackConfig.Enabled = $('#chkEnableSlack', form).checked();
+                        slackConfig.Enabled = $('#chkEnableSlack', form).checked;
                         slackConfig.SlackWebHookURI = $('#txtSlackWebHookUri', form).val();
                         slackConfig.Channel = $('#txtSlackChannel', form).val();
                         slackConfig.Emoji = $('#txtSlackEmoji', form).val();

--- a/Emby.Notification.Slack/Emby.Notification.Slack/SlackNotifier.cs
+++ b/Emby.Notification.Slack/Emby.Notification.Slack/SlackNotifier.cs
@@ -60,12 +60,14 @@ namespace Emby.Notification.Slack
                 slackMessage.text = request.Name + "\r\n" + request.Description;
             }
 
+            slackMessage.text = slackMessage.text.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
+
 
             var parameters = new Dictionary<string, string> { };
-            parameters.Add("payload", _jsonSerializer.SerializeToString(slackMessage));
+            parameters.Add("payload", System.Net.WebUtility.UrlEncode(_jsonSerializer.SerializeToString(slackMessage)));
 
             _logger.Debug("Slack to {0} - {1} - {2}", options.Channel, request.Name, request.Description);
-            _logger.Debug("Slack Payload: {0}", _jsonSerializer.SerializeToString(slackMessage));
+            _logger.Debug("Slack Payload: {0}", System.Net.WebUtility.UrlEncode(_jsonSerializer.SerializeToString(slackMessage)));
             var _httpRequest = new HttpRequestOptions
             {
                 Url = options.SlackWebHookURI,


### PR DESCRIPTION
Using Emby Server 4.3.1.0, the Slack Notification plugin configuration page failed to load.
These small changes let me use this plugin again. Please review this.